### PR TITLE
Ruby 2.0 support

### DIFF
--- a/iterm2mintty.gemspec
+++ b/iterm2mintty.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = "~> 2.1"
+  spec.required_ruby_version = ">= 2.0"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -2,13 +2,13 @@ require "helper"
 require "iterm2mintty/cli"
 
 module Iterm2mintty
-  class CLITest < MiniTest::Test
+  class CLITest < Minitest::Unit::TestCase
     def test_run
-      io = MiniTest::Mock.new
+      io = Minitest::Mock.new
       args = ["test/fixtures/Hybrid.itermcolors"]
 
-      io.expect("puts", String.new, [String])
-      io.expect("close_on_exec?", false)
+      io.expect(:puts, String.new, [String])
+      io.expect(:autoclose?, false)
 
       CLI.new(args, io: io).run
     end

--- a/test/test_converter.rb
+++ b/test/test_converter.rb
@@ -2,7 +2,7 @@ require "helper"
 require "iterm2mintty/converter"
 
 module Iterm2mintty
-  class ConverterTest < MiniTest::Test
+  class ConverterTest < Minitest::Unit::TestCase
     def setup
       @to = MiniTest::Mock.new
       @from = MiniTest::Mock.new

--- a/test/test_iterm2_theme.rb
+++ b/test/test_iterm2_theme.rb
@@ -2,7 +2,7 @@ require "helper"
 require "iterm2mintty/iterm2_theme_parser"
 
 module Iterm2mintty
-  class Iterm2ThemeParserTest < MiniTest::Test
+  class Iterm2ThemeParserTest < Minitest::Unit::TestCase
     def setup
       itermcolors = Pathname.new("test/fixtures/Hybrid.itermcolors")
       @parser = Iterm2ThemeParser.new(itermcolors)

--- a/test/test_iterm2mintty.rb
+++ b/test/test_iterm2mintty.rb
@@ -1,6 +1,6 @@
 require "helper"
 
-class Iterm2minttyTest < MiniTest::Test
+class Iterm2minttyTest < Minitest::Unit::TestCase
   def setup
     @path = Pathname.new("test/fixtures/Hybrid.itermcolors")
   end

--- a/test/test_mintty_theme.rb
+++ b/test/test_mintty_theme.rb
@@ -2,7 +2,7 @@ require "helper"
 require "iterm2mintty/mintty_theme"
 
 module Iterm2mintty
-  class MinttyThemeTest < MiniTest::Test
+  class MinttyThemeTest < Minitest::Unit::TestCase
     def setup
       @components = [
         BlackComponent.new(0, 0, 0),


### PR DESCRIPTION
- required ruby verison ~> 2.0
- older Minitest names required for tests to run in older ruby versions.

fixes #3
